### PR TITLE
Norminette flags corrected

### DIFF
--- a/norminette_tester.sh
+++ b/norminette_tester.sh
@@ -61,9 +61,9 @@ for f in $(ls *.h *.c); do
 	fi
 
 	if expr "$f" : '.*\.c$' > /dev/null; then
-		norminette $f > $tmpFile
-	else
 		norminette -R CheckForbiddenSourceHeader $f > $tmpFile
+	else
+		norminette -R CheckDefine $f > $tmpFile
 	fi &&
 	echo "$f:\t${LGREEN}OK!${NC}" ||
 	{


### PR DESCRIPTION
Not sure if 'CheckDefine' is always needed on '.h' files, but I guess if it's not needed, it wouldn't hurt to have it anyways.